### PR TITLE
stringify UNIT_CATEGORY wood value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2029,7 +2029,7 @@ export enum UNIT_CATEGORY {
     waitingroom="waitingroom",
     walkway="walkway",
     "walkway.island"="walkway.island",
-    wood=wood
+    wood="wood"
 }
 
 /**


### PR DESCRIPTION
This is creating an error when doing `Object.values(UNIT_CATEGORY)`